### PR TITLE
chore: 升级 @kne/modules-dev 至 ^2.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-thirdparty",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "用于封装一些体积较大的需要使用时再加载的第三方库",
   "scripts": {
     "init": "husky",
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@kne/craco": "^7.1.3",
-    "@kne/modules-dev": "^2.3.0",
+    "@kne/modules-dev": "^2.4.10",
     "@kne/react-fetch": "^1.4.3",
     "@kne/remote-loader": "^1.4.0",
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
## Summary
- 将 `@kne/modules-dev` 从 `^2.3.0` 升级到 `^2.4.10`（含生产构建 `concatenateModules: false`，避免 MF 远程包 TDZ）
- 本包 version：`0.1.33` → `0.1.34`

## Test plan
- [ ] 合并后确认 Publish workflow 发布 `@kne-components/components-thirdparty@0.1.34`
- [ ] 本地 `npm start` 能正常启动 example

Made with [Cursor](https://cursor.com)